### PR TITLE
Added branch parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ This action builds AIX extension for MIT App Inventor by compiling your .java so
 
 The git URL of App Inventor sources repository to compile your extension. Default is `https://github.com/mit-cml/appinventor-sources.git`.
 
+### `branch`
+
+A valid branch name of your App Inventor source repository which extensions will build from. Default is `master`.
+
 ## Outputs
 
 ### `file`

--- a/action.yml
+++ b/action.yml
@@ -5,9 +5,13 @@ branding:
   color: 'green'
 inputs:
   source:  # id of input
-    description: 'The git URL of App Inventor sources.'
+    description: 'The git URL of your App Inventor sources.'
     required: true
     default: 'https://github.com/mit-cml/appinventor-sources.git'
+  branch:
+    description: 'A valid branch name of your App Inventor source repository which extensions will build from.'
+    required: false
+    default: 'master'
 outputs:
   file: # id of output
     description: 'The AIX extension file name.'
@@ -16,3 +20,4 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{ inputs.source }}
+    - ${{ inputs.branch }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,7 @@ apt-get update && apt-get install -y \
   openjdk-8-jdk
 
 git clone $1
+git checkout $2
 git submodule update --init
 
 cp -r src/** appinventor-sources/appinventor/components/src


### PR DESCRIPTION
Closes #1 

This PR adds `branch` parameter which can be used for building extensions from another branch. As it is a optional parameter, it doesn't cause any problems for old workflow files.